### PR TITLE
✨ mdx파일에서 외부 링크만 새 탭 여는 기능 추가

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -3,6 +3,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
 import rehypePrettyCode from 'rehype-pretty-code';
+import rehypeExternalLinks from 'rehype-external-links';
 
 export const Post = defineDocumentType(() => ({
   name: 'Posts',
@@ -58,6 +59,16 @@ export default makeSource({
           properties: {
             className: ['anchor'],
           },
+        },
+      ],
+      [
+        rehypeExternalLinks,
+        {
+          properties: {
+            class: 'external-link',
+          },
+          target: '_blank',
+          rel: ['noopener noreferrer'],
         },
       ],
     ],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18",
     "react-dom": "^18",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-external-links": "^3.0.0",
     "rehype-pretty-code": "^0.13.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "3.0.1",

--- a/posts/otter/main/sub/0-markdown-test.mdx
+++ b/posts/otter/main/sub/0-markdown-test.mdx
@@ -1,0 +1,17 @@
+---
+title: 'markdown test'
+summary: 'markdown test용 posting입니다.'
+date: 2024-2-24
+author: 'otter'
+tags: ['markdown']
+---
+
+## 마크다운
+
+markdown test용 posting입니다.
+
+[내부링크, url 주소만](/na-log)
+
+[외부링크, http://를 붙일 때](https://nerd-animals.github.io/na-log/)
+
+https://nerd-animals.github.io/na-log/

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,11 @@ internal-slot@^1.0.5, internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
+is-absolute-url@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-4.0.1.tgz#16e4d487d4fded05cfe0685e53ec86804a5e94dc"
+  integrity sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==
+
 is-alphabetical@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
@@ -4170,6 +4175,18 @@ rehype-autolink-headings@^7.1.0:
     hast-util-heading-rank "^3.0.0"
     hast-util-is-element "^3.0.0"
     unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+
+rehype-external-links@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-external-links/-/rehype-external-links-3.0.0.tgz#2b28b5cda1932f83f045b6f80a3e1b15f168c6f6"
+  integrity sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-is-element "^3.0.0"
+    is-absolute-url "^4.0.0"
+    space-separated-tokens "^2.0.0"
     unist-util-visit "^5.0.0"
 
 rehype-parse@^9.0.0:


### PR DESCRIPTION
## summary

mdx파일에서 외부 링크만 새 탭 여는 기능을 추가하였습니다.

- Resolves: #40

## PR 유형

어떤 유형인가요? 해당되는 유형에 체크해주세요.

**PR 제목 작성시 '[유형에 맞는 gitmoji] 제목'으로 입력 부탁드립니다.**

- [x] ✨ Feature / 새로운 기능
- [ ] 🐛 Fix / 버그 수정
- [ ] 💄 Style / CSS 등 사용자 UI 디자인 변경
- [ ] ♻️ Refactor / 코드 리팩토링(구조 개선, 디렉토리 변경 등...)
- [ ] 📝 Docs / 문서 수정
- [ ] ✅ Test / 테스트 추가, 테스트 리팩토링
- [ ] 💬 Chore / 그 외, 모든 변경점(Package, Rename, Remove, etc...)

## 변경 사항

| 기능  | 스크린샷 |
| :---: | -------- |
| As-is |          |
| To-be |![24 02 24 external-link](https://github.com/nerd-animals/na-log/assets/144116866/f4a6b477-7a5e-45a5-b949-2b5385e65efa)|

---

- [rehype-external-links](https://github.com/rehypejs/rehype-external-links) 라는 ``rehype`` 플러그인 기능으로 외부 링크("https://') 일 때만 class 및 새 탭으로 여는 기능, rel을 추가되도록 하였습니다.

  - 외부 링크에 rel: [['noopener noreferrer'](https://velog.io/@neori/HTML-a%EC%97%90-targetblank%EC%99%80-relnoreferrer-noopener%EB%A5%BC-%ED%95%A8%EA%BB%98-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0)] 를 붙여주는 이유는 보안상의 이유입니다. 링크된 페이지가 악의적인 페이지라면 보안상 심각한 문제가 발생할 수 있으므로 사전에 미리 방지해주는 것이 중요합니다.

---

## 참고 사항

### 마크다운 문법으로 바꾼 이유

<img width="516" alt="image" src="https://github.com/nerd-animals/na-log/assets/144116866/60ed1744-e0e4-4cdc-8e03-bec6cd578a16">


a링크를 [next/Link 컴포넌트](https://nextjs.org/docs/pages/building-your-application/configuring/mdx#custom-elements)로 바꾸는 아이디어를 의논하고 생각했으나, **Link 컴포넌트**는 [prefetch](https://nextjs.org/docs/pages/api-reference/components/link) 속성 때문에 외부 링크보다 **내부 링크**에 적합합니다.

그리고, Link 컴포넌트는 접근성, 브라우저 호환성, SEO 측면에서 a 태그를 이용하여 구현이 됐습니다.
따라서, mdx 파일을 사용할 시 ``포스팅 이용`` 측면에서도, ``SEO`` 측면에서도, ``통일성`` 측면에서도, ``직관성`` 측면에서도 markdown 문법을 활용하고, rehype 플러그인 기능으로 외부 링크일 때 자동 분류해주는 것이 좋아보입니다.



## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 정상 동작 확인 여부
- [x] commit message convention 충족 여부
